### PR TITLE
Added constraint for validating one not-empty from group of fields

### DIFF
--- a/src/main/java/net/formio/validation/constraints/AnyNotEmpty.java
+++ b/src/main/java/net/formio/validation/constraints/AnyNotEmpty.java
@@ -1,0 +1,60 @@
+package net.formio.validation.constraints;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Annotation defining validation so that at least one field
+ * from field list must not be empty.
+ * 
+ * @author Petr Kalivoda
+ *
+ */
+@Target({ TYPE, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = AnyNotEmptyValidator.class)
+@Documented
+public @interface AnyNotEmpty {
+	
+	public static final String MESSAGE = "{constraints.AnyNotEmpty.message}";
+	
+	/**
+	 * @return The error message template.
+	 */
+	String message() default MESSAGE;
+
+	/**
+	 * @return The groups the constraint belongs to.
+	 */
+	Class<?>[] groups() default { };
+
+	/**
+	 * @return The payload associated to the constraint
+	 */
+	Class<? extends Payload>[] payload() default {};
+
+	/**
+	 * @return Fields one of which must not be empty.
+	 */
+	String[] fields();
+
+	/**
+	 * Defines several <code>@AnyNotEmpty</code> annotations on the same element
+	 * 
+	 * @see AnyNotEmpty
+	 */
+	@Target({ TYPE, ANNOTATION_TYPE })
+	@Retention(RUNTIME)
+	@Documented
+	@interface List {
+		AnyNotEmpty[] value();
+	}
+}

--- a/src/main/java/net/formio/validation/constraints/AnyNotEmptyValidator.java
+++ b/src/main/java/net/formio/validation/constraints/AnyNotEmptyValidator.java
@@ -1,0 +1,81 @@
+package net.formio.validation.constraints;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import net.formio.validation.constraints.NotEmptyValidation;
+
+/**
+ * Constraint validating any non-empty field of list of fields
+ * 
+ * @author Petr Kalivoda
+ *
+ */
+public class AnyNotEmptyValidator implements ConstraintValidator<AnyNotEmpty, Object> {
+
+	private List<String> fieldNames;
+
+	@Override
+	public void initialize(AnyNotEmpty constraintAnnotation) {
+		fieldNames = Arrays.asList(constraintAnnotation.fields());
+	}
+
+	@Override
+	public boolean isValid(Object input, ConstraintValidatorContext context) {
+		for (String fieldName : fieldNames) {
+			try {
+				Object value = getPropertyValue(input, fieldName);
+				if (NotEmptyValidation.isNotEmpty(value)) {
+					return true;
+				}
+				
+			} catch (Exception ignore) {}
+		}
+		return false;
+	}
+
+	/**
+	 * Returns value of property on given bean.
+	 * 
+	 * @param bean
+	 * @param property
+	 * @return
+	 * @throws IllegalArgumentException
+	 * @throws IllegalAccessException
+	 * @throws IntrospectionException
+	 */
+	private Object getPropertyValue(Object bean, String property)
+			throws InvocationTargetException, IllegalAccessException, IllegalArgumentException, IntrospectionException {
+		return getReadMethod(bean.getClass(), property).invoke(bean);
+	}
+
+	/**
+	 * Returns getter for appropriate bean class.
+	 * 
+	 * @param beanClass
+	 * @param property
+	 * @return
+	 * @throws IntrospectionException
+	 */
+	private Method getReadMethod(Class<?> beanClass, String property) throws IntrospectionException {
+		BeanInfo beanInfo = Introspector.getBeanInfo(beanClass);
+		for (PropertyDescriptor pd : beanInfo.getPropertyDescriptors()) {
+			if (pd.getName().equals(property) && pd.getReadMethod() != null) {
+				return pd.getReadMethod();
+			}
+		}
+
+		throw new IllegalArgumentException(
+				"No getter available for property '" + property + "' in '" + beanClass + "'.");
+	}
+
+}

--- a/src/test/java/net/formio/data/TestForms.java
+++ b/src/test/java/net/formio/data/TestForms.java
@@ -32,6 +32,7 @@ import net.formio.domain.BigDecimalValue;
 import net.formio.domain.Car;
 import net.formio.domain.CarDimensions;
 import net.formio.domain.Collegue;
+import net.formio.domain.Contact;
 import net.formio.domain.Engine;
 import net.formio.domain.NewCollegue;
 import net.formio.domain.Person;
@@ -177,6 +178,11 @@ public final class TestForms {
 		.field("otherInfoUrl", Field.LINK)
 		.field("submitValue", Field.BUTTON)
 		.build(Location.ENGLISH);
+	
+	public static final FormMapping<Contact> CONTACT_FORM = Forms.basic(Contact.class, "contact")
+			.field("email", Field.EMAIL)
+			.field("phone", Field.TEL)
+			.build(Location.ENGLISH);
 	
 	private static List<Skill> skillsCodebook() {
 		List<Skill> skills = new ArrayList<Skill>();

--- a/src/test/java/net/formio/domain/Contact.java
+++ b/src/test/java/net/formio/domain/Contact.java
@@ -1,0 +1,27 @@
+package net.formio.domain;
+
+import java.io.Serializable;
+
+import net.formio.validation.constraints.AnyNotEmpty;
+
+@AnyNotEmpty(fields = {"email", "phone"})
+public class Contact implements Serializable {
+
+	private static final long serialVersionUID = -3737080347468640583L;
+	
+	private String email;
+	private String phone;
+	
+	public String getEmail() {
+		return email;
+	}
+	public void setEmail(String email) {
+		this.email = email;
+	}
+	public String getPhone() {
+		return phone;
+	}
+	public void setPhone(String phone) {
+		this.phone = phone;
+	}
+}

--- a/src/test/java/net/formio/validation/constraints/AnyNotEmptyValidationTest.java
+++ b/src/test/java/net/formio/validation/constraints/AnyNotEmptyValidationTest.java
@@ -1,0 +1,57 @@
+package net.formio.validation.constraints;
+
+import org.junit.Test;
+
+import junit.framework.Assert;
+import net.formio.FormData;
+import net.formio.FormMapping;
+import net.formio.data.TestForms;
+import net.formio.domain.Contact;
+import net.formio.inmemory.MapParams;
+
+/**
+ * Tests for {@link AnyNotEmpty}
+ * @author Petr Kalivoda
+ *
+ */
+public class AnyNotEmptyValidationTest {
+	@Test
+	public void testBothFilled() {
+		FormMapping<Contact> contactForm = TestForms.CONTACT_FORM;
+		FormData<Contact> contactData = newFormData(contactForm, "proper.email@example", "+420000000");
+		Assert.assertTrue("validation with both filled should yield true", contactData.isValid());
+		
+	}
+	
+	@Test
+	public void testEmailFilled() {
+		FormMapping<Contact> contactForm = TestForms.CONTACT_FORM;
+		FormData<Contact> contactData = newFormData(contactForm, "proper.email@example", null);
+		Assert.assertTrue("validation with only first filled should yield true", contactData.isValid());
+	}
+	
+	@Test
+	public void testPhoneFilled() {
+		FormMapping<Contact> contactForm = TestForms.CONTACT_FORM;
+		FormData<Contact> contactData = newFormData(contactForm, null, "+420000000");
+		Assert.assertTrue("validation with only second filled should yield true", contactData.isValid());
+	}
+	
+	@Test
+	public void testNoneFilled() {
+		FormMapping<Contact> contactForm = TestForms.CONTACT_FORM;
+		FormData<Contact> contactData = newFormData(contactForm, null, null);
+		Assert.assertFalse("validation with none filled should yield false", contactData.isValid());
+	}
+	
+	public static FormData<Contact> newFormData(FormMapping<Contact> mapping, String email, String phone) {
+		return TestForms.CONTACT_FORM.bind(newContactFormParams(mapping.getConfig().getPathSeparator(), email, phone));
+	}
+	
+	public static MapParams newContactFormParams(String pathSep, String email, String phone) {
+		final MapParams reqParams = new MapParams();
+		reqParams.put("contact" + pathSep + "email", email);
+		reqParams.put("contact" + pathSep + "phone", phone);
+		return reqParams;
+	}
+}


### PR DESCRIPTION
I made a constraint enabling to specify that from a given list of fields, at least one must not be empty.
The use case is about conditions such as "please fill either e-mail or phone".

For example:
```
@AnyNotEmpty(fields = {"email", "phone"})
public class Contact implements Serializable { ...
```